### PR TITLE
Add missing isActive overloads

### DIFF
--- a/src/actionLoggingRouter.js
+++ b/src/actionLoggingRouter.js
@@ -32,11 +32,11 @@ export class ActionLoggingRouter {
         return {commands, extras};
     }
 
-    isActive(tree, excact) {
+    isActive(tree, matchOptions) {
         if (!this.activePath) {
             return false
         }
-        if (excact) {
+        if (matchOptions && (typeof matchOptions === 'boolean' || matchOptions.paths === 'exact')) {
             return this._joinCommands(tree) === this.activePath
         }
         return this._joinCommands(tree).startsWith(this.activePath);
@@ -54,6 +54,9 @@ export class ActionLoggingRouter {
     }
 
     _joinCommands(tree) {
+        if(typeof tree === 'string') {
+            return tree;
+        }
         return tree.commands.join('/');
     }
 

--- a/src/actionLoggingRouter.spec.js
+++ b/src/actionLoggingRouter.spec.js
@@ -59,6 +59,14 @@ describe('ActionLoggingRouter', () => {
             )).toBe(true)
         });
 
+        it('should be active when exact and routes match with options', () => {
+            expect(router.isActive(
+                {commands: ['path', 'nested']},
+                {paths: 'exact', queryParams: 'exact', fragment: 'ignored', matrixParams: 'ignored'}
+            )).toBe(true)
+        });
+
+
         it('should be active when not exact and routes match', () => {
             expect(router.isActive(
                 {commands: ['path', 'nested']},
@@ -84,6 +92,13 @@ describe('ActionLoggingRouter', () => {
             expect(router.isActive(
                 {commands: ['path', 'nested', 'deep']},
                 false
+            )).toBe(true)
+        });
+
+        it('should be active when not exact and routes match partly with options', () => {
+            expect(router.isActive(
+                {commands: ['path', 'nested', 'deep']},
+                {paths: 'subset', queryParams: 'exact', fragment: 'ignored', matrixParams: 'ignored'}
             )).toBe(true)
         });
 


### PR DESCRIPTION
Fixes #24
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.9.2--canary.25.f96e573.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install storybook-addon-angular-router@1.9.2--canary.25.f96e573.0
  # or 
  yarn add storybook-addon-angular-router@1.9.2--canary.25.f96e573.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
